### PR TITLE
In-game music playback

### DIFF
--- a/Gtk/Makefile
+++ b/Gtk/Makefile
@@ -17,8 +17,8 @@
 
 ########################################################################
 
-SOUND_SYSTEM = SMPEG
-# SOUND_SYSTEM = SDL_MIXER
+# SOUND_SYSTEM = SMPEG
+SOUND_SYSTEM = SDL_MIXER
 # SOUND_SYSTEM = XMMS
 # SOUND_SYSTEM = NONE
 
@@ -54,7 +54,8 @@ endif
 
 ifeq ($(SOUND_SYSTEM),SDL_MIXER)
 	OBJS += sound_sdlmixer.o
-	SOUND_LIBS = `sdl-config --libs` -lSDL_mixer
+	SOUND_LIBS = `sdl2-config --libs` -lSDL2_mixer
+	CFLAGS += -DSDL_MIXER
 endif
 
 ifeq ($(SOUND_SYSTEM),XMMS)
@@ -93,7 +94,7 @@ sound_smpeg.o: sound_smpeg.c sound.h
 	$(CC) -c $(CFLAGS) `sdl-config --cflags` sound_smpeg.c
 
 sound_sdlmixer.o: sound_sdlmixer.c sound.h
-	$(CC) -c $(CFLAGS) `sdl-config --cflags` sound_sdlmixer.c
+	$(CC) -c $(CFLAGS) `sdl2-config --cflags` sound_sdlmixer.c
 
 sound_xmms.o: sound_xmms.c sound.h
 	$(CC) -c $(CFLAGS) `xmms-config --cflags` sound_xmms.c

--- a/Gtk/NEWS
+++ b/Gtk/NEWS
@@ -1,3 +1,13 @@
+2024-12-XX - 1.6 addendum (The "I ATE'NT DEAD" release.)
+
+Bugfixes
+
+- Switched SDL sound backend to SDL 2 so it actually works.
+
+Other changes
+
+- Wonderland can now play in-game music from a sound file.
+
 2005-08-XX - 1.6 (The "Syncing feeling" release.)
 
 Re-sync with GtkLevel9 1.3:

--- a/Gtk/gui.c
+++ b/Gtk/gui.c
@@ -51,7 +51,7 @@ void gui_refresh ()
 
 static void do_open ()
 {
-    start_new_game (NULL, NULL, NULL, NULL, NULL);
+    start_new_game (NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 static void do_quit ()

--- a/Gtk/main.c
+++ b/Gtk/main.c
@@ -28,6 +28,7 @@
 #include "text.h"
 #include "graphics.h"
 #include "hints.h"
+#include "sound.h"
 #include "util.h"
 
 static gboolean main_loop (gpointer data);
@@ -179,6 +180,9 @@ void ms_fatal (type8s *txt)
 
 void ms_playmusic(type8 * midi_data, type32 length, type16 tempo)
 {
+    #ifdef SDL_MIXER
+    sound_play_midi (midi_data, length, tempo);
+    #endif
 }
 
 void do_about ()
@@ -257,7 +261,7 @@ static gchar *change_file_extension (gchar *filename, gchar *extension)
 
 gboolean start_new_game (gchar *game_filename, gchar *graphics_filename,
 			 gchar *splash_filename, gchar *music_filename,
-			 gchar *hints_filename)
+			 gchar *hints_filename, gchar *sound_filename)
 {
     const gchar *filters[] =
 	{
@@ -295,6 +299,9 @@ gboolean start_new_game (gchar *game_filename, gchar *graphics_filename,
     if (!hints_filename)
 	hints_filename = change_file_extension (game_filename, "hnt");
 
+    if (!sound_filename)
+    sound_filename = change_file_extension (game_filename, "snd");
+
     display_splash_screen (splash_filename, music_filename);
 
     text_clear ();
@@ -304,7 +311,7 @@ gboolean start_new_game (gchar *game_filename, gchar *graphics_filename,
     if (applicationExiting)
 	return FALSE;
 
-    if (!ms_init ((type8s *) game_filename, (type8s *) graphics_filename, (type8s *) hints_filename, NULL))
+    if (!ms_init ((type8s *) game_filename, (type8s *) graphics_filename, (type8s *) hints_filename, (type8s *) sound_filename))
     {
 	GtkWidget *error;
 	gchar *basename;
@@ -329,6 +336,7 @@ gboolean start_new_game (gchar *game_filename, gchar *graphics_filename,
     g_free (splash_filename);
     g_free (music_filename);
     g_free (hints_filename);
+    g_free (sound_filename);
     
     gtk_widget_grab_focus (Gui.text_view);
     return TRUE;
@@ -341,6 +349,7 @@ int main (int argc, char *argv[])
     gchar *splash_filename = NULL;
     gchar *music_filename = NULL;
     gchar *hints_filename = NULL;
+    gchar *sound_filename = NULL;
 
     gtk_init (&argc, &argv);
 
@@ -350,6 +359,8 @@ int main (int argc, char *argv[])
 
     read_config_file ();
 
+    if (argc >= 7)
+    sound_filename = g_strdup (argv[6]);
     if (argc >= 6)
 	hints_filename = g_strdup (argv[5]);
     if (argc >= 5)
@@ -367,7 +378,8 @@ int main (int argc, char *argv[])
 			graphics_filename,
 			splash_filename,
 			music_filename,
-			hints_filename))
+			hints_filename,
+			sound_filename))
 	gtk_main ();
 
     return 0;  

--- a/Gtk/main.h
+++ b/Gtk/main.h
@@ -27,7 +27,7 @@ void stop_main_loop (void);
 
 gboolean start_new_game (gchar *game_filename, gchar *graphics_filename,
 			 gchar *splash_filename, gchar *music_filename,
-			 gchar *hints_filename);
+			 gchar *hints_filename, gchar *sound_filename);
 
 void do_about (void);
 void close_application (GtkWidget *widget, gpointer user_data);

--- a/Gtk/sound.h
+++ b/Gtk/sound.h
@@ -20,7 +20,10 @@
 #ifndef _SOUND_H
 #define _SOUND_H
 
+#include "../Generic/defs.h"
+
 void sound_start_music (gchar *filename);
 void sound_stop_music (void);
+void sound_play_midi (type8 *midi_data, type32 length, type16 tempo);
 
 #endif


### PR DESCRIPTION
Gtk version was lacking support for in-game music that should play while entering certain locations in Wonderland. This remedies the situation. 

Switched the default sound backend to SDL 2, as SMPEG is mostly obsolete and doesn't support MIDI playback. Still, it was left intact for use on legacy systems.

All it needs to play in-game music is a proper MIDI setup working with sdl-mixer. Tested with several distros. Contemporary Debian-based distros pull all the necessary dependencies with sdl-mixer, but it works without much hassle on more esoteric setups as well, provided the OS is properly configured to play MIDI, e.g. using Fluidsynth. If MIDI is unavailable for whatever reason, the game continues as normal.