### PR TITLE
Regression fix

### DIFF
--- a/Gtk/NEWS
+++ b/Gtk/NEWS
@@ -6,7 +6,7 @@ Other changes
 
 - There's now a toggle in the options for horizontal viewscreen split.
 
-- There's now a proper application icon.
+- Bundled desktop entry, MIME type definition and application icon.
 
 2024-12-XX - 1.6 addendum (The "I ATE'NT DEAD" release.)
 

--- a/Gtk/gtkmagnetic.desktop
+++ b/Gtk/gtkmagnetic.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Magnetic
+GenericName=Magnetic Scrolls interpreter
+Comment=An interpreter for games from the British text adventure company Magnetic Scrolls
+Exec=gtkmagnetic %U
+Icon=gtkmagnetic
+Terminal=false
+Categories=GTK;Application;Game;
+StartupNotify=true
+MimeType=application/x-magscroll;

--- a/Gtk/gtkmagnetic.xml
+++ b/Gtk/gtkmagnetic.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="application/x-magscroll">
+    <comment>Magnetic Scrolls game data</comment>
+    <magic priority="50">
+      <match type="string" offset="0" value="MaSc"/>
+    </magic>
+    <glob pattern="*.mag"/>
+    <icon name="gtkmagnetic"/>
+  </mime-type>
+</mime-info>

--- a/Gtk/gui.c
+++ b/Gtk/gui.c
@@ -151,12 +151,19 @@ void gui_init ()
     Gui.main_window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_window_set_title (GTK_WINDOW (Gui.main_window), "GtkMagnetic");
 
-    icon = gdk_pixbuf_new_from_file  ("gtkmagnetic.png", NULL);
+    GtkIconTheme *theme = gtk_icon_theme_get_default ();
+    icon = gtk_icon_theme_load_icon (theme, "gtkmagnetic", 32, 0, NULL);
+
+    if (!icon) {
+	icon = gdk_pixbuf_new_from_file ("gtkmagnetic.png", NULL);
+    }
+
     if (icon) {
         gtk_window_set_icon (GTK_WINDOW (Gui.main_window), icon);
         gtk_window_set_default_icon (icon);
         g_object_unref (icon);
     }
+
     gtk_widget_set_size_request (Gui.main_window, MIN_WINDOW_WIDTH,
 				 MIN_WINDOW_HEIGHT);
 
@@ -230,8 +237,8 @@ void gui_init ()
 	Gui.text_buffer, "magnetic-old-input", "weight", PANGO_WEIGHT_BOLD,
 	"editable", FALSE, NULL);
     gtk_text_buffer_create_tag (
-    Gui.text_buffer, "magnetic-input-padding",
-    "weight", PANGO_WEIGHT_BOLD, "editable", TRUE, NULL);
+	Gui.text_buffer, "magnetic-input-padding",
+	"weight", PANGO_WEIGHT_BOLD, "editable", TRUE, NULL);
 
     Gui.text_view = gtk_text_view_new_with_buffer (Gui.text_buffer);
     gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (Gui.text_view), GTK_WRAP_WORD);

--- a/Gtk/text.c
+++ b/Gtk/text.c
@@ -309,7 +309,7 @@ void text_init ()
      * ENTER or Up/Down-arrow, and to make sure the text at the command prompt
      * stays editable.
      */
-    
+
     hSigInsert = g_signal_connect_after (
 	G_OBJECT (Gui.text_buffer), "insert-text",
 	G_CALLBACK (sig_insert), NULL);
@@ -655,7 +655,7 @@ static gboolean sig_keypress (GtkWidget *widget, GdkEventKey *event,
 	default:
 	    break;
     }
-    
+
     return FALSE;
 }
 
@@ -923,6 +923,10 @@ void ms_flush ()
 	    Gui.text_buffer, &end, line_count - MAX_SCROLLBACK);
 
 	gtk_text_buffer_delete (Gui.text_buffer, &start, &end);
+
+	gtk_widget_queue_draw (Gui.text_view);
+	while (gtk_events_pending ())
+	    gtk_main_iteration_do (FALSE);
     }
 
     set_input_pending (TRUE);
@@ -957,6 +961,7 @@ type8 ms_getchar (type8 trans)
 	     * It's not quite a substitute for a "more" prompt, but it will
 	     * have to do for now.
 	     */
+	    gtk_text_buffer_get_end_iter (Gui.text_buffer, &iter);
 	    gtk_text_view_scroll_to_mark (
 		GTK_TEXT_VIEW (Gui.text_view), inputMark,
 		0.0, TRUE, 0.0, 0.0);


### PR DESCRIPTION
There's this sneaky regression where filling up the text buffer will break autoscrolling, requiring the player to press a key or scroll the viewport after every input to catch up with the new text.
The text buffer can hold 500 lines of text (a line of text here is an arbitrary length string ending with a newline, and can span multiple visual lines), so this bug requires an extended playthrough to appear, and even then it's not obvious what's causing this odd behaviour. Actually found it whilst playing around with Level 9 (their games tend to be wordier, I think), and fixed it there, but then it turned out the issue is present here as well. It's actually rather harmless, but irritating when it finally happens, so here's a fix.

Also added the XDG fluff to keep things on par with Level 9, so this is like a small maintenance PR. I'll keep these to a minimum unless something comes up.