### PR TITLE
GTK: QoL update

### DIFF
--- a/Gtk/NEWS
+++ b/Gtk/NEWS
@@ -1,3 +1,47 @@
+2025-11-XX - 2.1 ("The other castle" release.)
+
+Bugfixes
+
+- Fixed unresponsive input after loading a new game when the previous
+  game session was ended with the "quit" command.
+
+- Fixed parsing of floating-point numbers in the configuration file to
+  avoid issues with system locales using commas as decimal separators.
+
+- Enforced a minimum fifty-pixel gap between the movable viewport
+  divider and the window edge to prevent accidentally collapsing either
+  pane to zero width or height during window resizing.
+
+Other changes
+
+- Improved font rendering quality with antialiasing, light hinting
+  and subpixel rendering.
+
+- Adjusted text margins and line spacing for readability and made them
+  user-configurable.
+
+- Added a graphics scaling option to dynamically fit the viewport size,
+  and made it the default for new configs.
+
+- The graphics pane can now be positioned above, below, to the left or
+  to the right side of the text, or hidden completely for a text-only
+  mode. This replaces the previous horizontal split feature.
+
+- Reworked the preferences dialog with live preview, keyboard mnemonics,
+  and reset buttons.
+
+- Added a quit confirmation dialog.
+
+- Added an option to enable graphics for Magnetic Windows games
+  (Wonderland and Collection games) at game startup, so it's no longer
+  necessary to manually enter "graphics on" at the prompt.
+
+- Migrated the configuration file to XDG .config directory. Old config
+  found in user's home directory will be automatically copied over.
+
+- "Image height" and "Scale factor" were both duplicating a similar
+  feature, so they've been reworked into a single "Custom scale" option.
+
 2025-02-XX - 2.0 (The "Can't have your cake and eat it" release.)
 
 Port to GTK 3.

--- a/Gtk/config.c
+++ b/Gtk/config.c
@@ -145,13 +145,13 @@ void write_config_file ()
 	    "  <graphics>\n"
 	    "    <constant_height>%s</constant_height>\n"
 	    "    <fit_to_window>%s</fit_to_window>\n"
-	    "    <scale>%f</scale>\n"
+	    "    <scale>%.2f</scale>\n"
 	    "    <height>%d</height>\n"
 	    "    <filter>%d</filter>\n"
 	    "    <gamma>\n"
-	    "      <red>%f</red>\n"
-	    "      <green>%f</green>\n"
-	    "      <blue>%f</blue>\n"
+	    "      <red>%.2f</red>\n"
+	    "      <green>%.2f</green>\n"
+	    "      <blue>%.2f</blue>\n"
 	    "    </gamma>\n"
 	    "    <background>%s</background>\n"
 	    "    <animate>%s</animate>\n"
@@ -441,8 +441,15 @@ static void config_parse_text (GMarkupParseContext *context,
 	*parserBool = (strcmp (text, "TRUE") == 0) ? TRUE : FALSE;
     else if (parserInt)
 	*parserInt = (gint) g_ascii_strtod (text, NULL);
-    else if (parserFloat)
-	*parserFloat = g_ascii_strtod (text, NULL);
+    else if (parserFloat) {
+	gchar *text_copy = g_strdup (text);
+	gchar *p;
+	for (p = text_copy; *p; p++) {
+	    if (*p == ',') *p = '.';
+	}
+	*parserFloat = g_ascii_strtod (text_copy, NULL);
+	g_free (text_copy);
+    }
     else if (parserChar)
     {
 	if (*parserChar)

--- a/Gtk/config.c
+++ b/Gtk/config.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <gtk/gtk.h>
+#include <glib/gstdio.h>
 
 #include "config.h"
 #include "gui.h"
@@ -43,12 +44,15 @@ Configuration Config =
     MIN_WINDOW_WIDTH,       /* hints window width                   */
     MIN_WINDOW_HEIGHT,      /* hints window height                  */
     NULL,                   /* text font                            */
+    20,                     /* text margin                          */
+    1.0,                    /* text leading                         */
     NULL,                   /* text foreground colour               */
     NULL,                   /* text background colour               */
     NULL,                   /* statusline font                      */
     NULL,                   /* statusline foreground colour         */
     NULL,                   /* statusline background colour         */
     FALSE,                  /* scale image to constant height?      */
+    TRUE,                   /* fit to window                        */
     1.0,                    /* image scaling                        */
     300,                    /* constant image height                */
     GDK_INTERP_BILINEAR,    /* interpolation mode for image scaling */
@@ -58,7 +62,8 @@ Configuration Config =
     NULL,                   /* graphics background colour           */
     TRUE,                   /* animate images                       */
     100,                    /* animation delay (ms)                 */
-    FALSE                   /* horizontal split                     */
+     0,                     /* graphics position (0=above)          */
+    TRUE                    /* startup graphics for magwin games    */
 };
 
 /* ------------------------------------------------------------------------- *
@@ -67,12 +72,18 @@ Configuration Config =
 
 static gchar *get_config_filename ()
 {
-    /*
-     * GLIB 2.6 introduced a g_get_user_config_dir() function. Perhaps we
-     * should use that instead, but I don't want want to write the migration
-     * code for it.
-     */
-    return g_build_filename (g_get_home_dir (), ".gtkmagnetic", NULL);
+    gchar *new_path = g_build_filename (
+	g_get_user_config_dir (), "gtkmagnetic", NULL);
+    if (!g_file_test (new_path, G_FILE_TEST_EXISTS)) {
+	gchar *old_path = g_build_filename (
+	    g_get_home_dir (), ".gtkmagnetic", NULL);
+	if (g_file_test (old_path, G_FILE_TEST_EXISTS)) {
+	    g_mkdir_with_parents (g_get_user_config_dir (), 0755);
+	    g_rename (old_path, new_path);
+	}
+	g_free (old_path);
+    }
+    return new_path;
 }
 
 /* ------------------------------------------------------------------------- *
@@ -109,7 +120,6 @@ void write_config_file ()
 	    "      <width>%d</width>\n"
 	    "      <height>%d</height>\n"
 	    "      <split>%d</split>\n"
-	    "      <horizontal_split>%s</horizontal_split>\n"
 	    "    </main_window>\n\n"
 	    
 	    "    <hints_window>\n"
@@ -120,6 +130,8 @@ void write_config_file ()
 	    
 	    "  <text>\n"
 	    "    <font>%s</font>\n"
+	    "    <margin>%d</margin>\n"
+	    "    <leading>%.2f</leading>\n"
 	    "    <foreground>%s</foreground>\n"
 	    "    <background>%s</background>\n"
 	    "  </text>\n\n"
@@ -132,6 +144,7 @@ void write_config_file ()
 	    
 	    "  <graphics>\n"
 	    "    <constant_height>%s</constant_height>\n"
+	    "    <fit_to_window>%s</fit_to_window>\n"
 	    "    <scale>%f</scale>\n"
 	    "    <height>%d</height>\n"
 	    "    <filter>%d</filter>\n"
@@ -143,23 +156,27 @@ void write_config_file ()
 	    "    <background>%s</background>\n"
 	    "    <animate>%s</animate>\n"
 	    "    <delay>%d</delay>\n"
+	    "    <graphics_position>%d</graphics_position>\n"
+	    "    <auto_graphics_magwin>%s</auto_graphics_magwin>\n"
 	    "  </graphics>\n"
 	    "</configuration>\n",
-	    CONFIG_VERSION_MINOR,
 	    CONFIG_VERSION_MAJOR,
+	    CONFIG_VERSION_MINOR,
 	    Config.window_width,
 	    Config.window_height,
 	    Config.window_split,
-	    Config.horizontal_split ? "TRUE" : "FALSE",
 	    Config.hints_width,
 	    Config.hints_height,
 	    Config.text_font ? Config.text_font : "",
+	    Config.text_margin,
+	    Config.text_leading,
 	    Config.text_fg ? Config.text_fg : "",
 	    Config.text_bg ? Config.text_bg : "",
 	    Config.status_font ? Config.status_font : "",
 	    Config.status_fg ? Config.status_fg : "",
 	    Config.status_bg ? Config.status_bg : "",
 	    Config.image_constant_height ? "TRUE" : "FALSE",
+	    Config.fit_to_window ? "TRUE" : "FALSE",
 	    Config.image_scale,
 	    Config.image_height,
 	    Config.image_filter,
@@ -168,7 +185,9 @@ void write_config_file ()
 	    Config.blue_gamma,
 	    Config.graphics_bg ? Config.graphics_bg : "",
 	    Config.animate_images ? "TRUE" : "FALSE",
-	    Config.animation_delay);
+	    Config.animation_delay,
+	    Config.graphics_position,
+	    Config.auto_graphics_magwin ? "TRUE" : "FALSE");
 
 	g_io_channel_write_chars (file, buf, -1, &bytes_written, &error);
 	g_free (buf);
@@ -284,8 +303,6 @@ static void config_parse_start_element (GMarkupParseContext *context,
 		parserInt = &(Config.window_height);
 	    else if (strcmp (element_name, "split") == 0)
 		parserInt = &(Config.window_split);
-	    else if (strcmp (element_name, "horizontal_split") == 0)
-		parserBool = & (Config.horizontal_split);
 	    break;
 
 	case CONFIG_PARSE_LAYOUT_HINTS_WINDOW:
@@ -298,6 +315,10 @@ static void config_parse_start_element (GMarkupParseContext *context,
 	case CONFIG_PARSE_TEXT:
 	    if (strcmp (element_name, "font") == 0)
 		parserChar = &(Config.text_font);
+	    else if (strcmp (element_name, "margin") == 0)
+		parserInt = &(Config.text_margin);
+	    else if (strcmp (element_name, "leading") == 0)
+		parserFloat = &(Config.text_leading);
 	    else if (strcmp (element_name, "background") == 0)
 		parserChar = &(Config.text_bg);
 	    else if (strcmp (element_name, "foreground") == 0)
@@ -316,6 +337,8 @@ static void config_parse_start_element (GMarkupParseContext *context,
 	case CONFIG_PARSE_GRAPHICS:
 	    if (strcmp (element_name, "constant_height") == 0)
 		parserBool = &(Config.image_constant_height);
+	    else if (strcmp (element_name, "fit_to_window") == 0)
+		parserBool = &(Config.fit_to_window);
 	    else if (strcmp (element_name, "scale") == 0)
 		parserFloat = &(Config.image_scale);
 	    else if (strcmp (element_name, "height") == 0)
@@ -330,6 +353,10 @@ static void config_parse_start_element (GMarkupParseContext *context,
 		parserBool = &(Config.animate_images);
 	    else if (strcmp (element_name, "delay") == 0)
 		parserInt = &(Config.animation_delay);
+	    else if (strcmp (element_name, "graphics_position") == 0)
+		parserInt = &(Config.graphics_position);
+	    else if (strcmp (element_name, "auto_graphics_magwin") == 0)
+		parserBool = &(Config.auto_graphics_magwin);
 	    break;
 
 	case CONFIG_PARSE_GRAPHICS_GAMMA:
@@ -488,42 +515,90 @@ static void toggle_sensitivity (GtkToggleButton *toggle_button,
 	gtk_widget_set_sensitive (GTK_WIDGET (user_data), FALSE);
 }
 
-static GtkWidget *add_font_button (GtkWidget *tab, gchar *text, gchar *title)
+static void spin_changed_int (GtkSpinButton *spin, gpointer user_data)
 {
+    gint *target = (gint *) user_data;
+    if (GTK_IS_SPIN_BUTTON (spin)) {
+	*target = gtk_spin_button_get_value_as_int (spin);
+	text_refresh ();
+    }
+}
+
+static void spin_changed_float (GtkSpinButton *spin, gpointer user_data)
+{
+    gdouble *target = (gdouble *) user_data;
+    if (GTK_IS_SPIN_BUTTON (spin)) {
+	*target = gtk_spin_button_get_value (spin);
+	text_refresh ();
+    }
+}
+
+static void reset_value (GtkWidget *button, GtkWidget *widget)
+{
+    gdouble *default_value = g_object_get_data (
+	G_OBJECT (button), "default-value");
+    if (GTK_IS_SPIN_BUTTON (widget))
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (widget), *default_value);
+    else
+	gtk_range_set_value (GTK_RANGE (widget), *default_value);
+}
+
+static GtkWidget *add_reset_button (GtkWidget *widget, gdouble default_value)
+{
+    GtkWidget *button = gtk_button_new_from_icon_name (
+	"view-refresh", GTK_ICON_SIZE_BUTTON);
+    gtk_style_context_add_class (
+	gtk_widget_get_style_context (button), "flat");
+    gdouble *value = g_new (gdouble, 1);
+    *value = default_value;
+    g_object_set_data_full (G_OBJECT (button), "default-value", value, g_free);
+    g_signal_connect (button, "clicked", G_CALLBACK (reset_value), widget);
+    return button;
+}
+
+static void on_position_changed (GtkComboBox *combo, gpointer user_data)
+{
+    Config.graphics_position = gtk_combo_box_get_active (combo);
+    gui_refresh ();
+    graphics_refresh ();
+}
+
+static void on_font_reset_clicked (GtkWidget *btn, gpointer user_data);
+static GtkWidget *add_font_button_with_reset (
+    GtkWidget *tab, const gchar *text, const gchar *title,
+    const gchar *reset_font_name)
+{
+    GtkWidget *box;
     GtkWidget *label;
     GtkWidget *font_button;
+    GtkWidget *reset;
 
-    label = gtk_label_new (text);
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_pack_start (GTK_BOX (tab), box, FALSE, FALSE, 0);
+
+    label = gtk_label_new_with_mnemonic (text);
     gtk_label_set_xalign (GTK_LABEL (label), 0.0);
     gtk_label_set_yalign (GTK_LABEL (label), 0.5);
-    gtk_box_pack_start (GTK_BOX (tab), label, TRUE, TRUE, 0);
+    gtk_widget_set_size_request (label, 120, -1);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
 
     font_button = gtk_font_button_new ();
     gtk_font_button_set_title (GTK_FONT_BUTTON (font_button), title);
-    gtk_box_pack_start (GTK_BOX (tab), font_button, TRUE, TRUE, 0);
+    gtk_box_pack_start (GTK_BOX (box), font_button, TRUE, TRUE, 0);
+    gtk_label_set_mnemonic_widget (GTK_LABEL (label), font_button);
+
+    reset = gtk_button_new_from_icon_name ("view-refresh", GTK_ICON_SIZE_BUTTON);
+    gtk_style_context_add_class (gtk_widget_get_style_context (reset), "flat");
+    if (reset_font_name)
+	g_object_set_data_full (G_OBJECT (reset), "reset-font-name",
+	    g_strdup (reset_font_name), g_free);
+    g_object_set_data (G_OBJECT (reset), "reset-font-widget", font_button);
+    /* When clicked, set the chooser to default and emit signal */
+    g_signal_connect (reset, "clicked",
+	G_CALLBACK (on_font_reset_clicked), NULL);
+    gtk_box_pack_start (GTK_BOX (box), reset, FALSE, FALSE, 0);
 
     return font_button;
-}
-
-static GtkWidget *add_scale (GtkWidget *tab, gchar *text, gdouble min,
-			     gdouble max, gdouble step, gdouble value)
-{
-    GtkWidget *scale;
-    GtkWidget *label;
-
-    label = gtk_label_new (text);
-    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
-    gtk_label_set_yalign (GTK_LABEL (label), 0.5);
-    gtk_box_pack_start (GTK_BOX (tab), label, TRUE, TRUE, 0);
-    
-    scale = gtk_scale_new_with_range (
-    GTK_ORIENTATION_HORIZONTAL, min, max, step);
-    gtk_scale_set_digits (GTK_SCALE (scale), 2);
-    gtk_scale_set_value_pos (GTK_SCALE (scale), GTK_POS_RIGHT);
-    gtk_range_set_value (GTK_RANGE (scale), value);
-    gtk_box_pack_start (GTK_BOX (tab), scale, TRUE, TRUE, 0);
-
-    return scale;
 }
 
 typedef struct
@@ -531,6 +606,74 @@ typedef struct
     GtkWidget *checkbox;
     GtkWidget *button;
 } ColourSetting;
+
+static GtkWidget *add_combo_box_simple (
+    GtkWidget *tab,
+    const gchar *label_text,
+    const gchar **items,
+    gint n_items,
+    gint active)
+{
+    GtkWidget *box;
+    GtkWidget *label;
+    GtkWidget *combo;
+    gint i;
+
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_pack_start (GTK_BOX (tab), box, FALSE, FALSE, 0);
+
+    label = gtk_label_new_with_mnemonic (label_text);
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_widget_set_size_request (label, 120, -1);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+
+    combo = gtk_combo_box_text_new ();
+    for (i = 0; i < n_items; i++)
+	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), items[i]);
+    gtk_combo_box_set_active (GTK_COMBO_BOX (combo), active);
+    gtk_box_pack_start (GTK_BOX (box), combo, TRUE, TRUE, 0);
+    gtk_label_set_mnemonic_widget (GTK_LABEL (label), combo);
+
+    return combo;
+}
+static void on_font_reset_clicked (GtkWidget *btn, gpointer user_data);
+
+static GtkWidget *add_scale_with_reset (
+    GtkWidget *tab,
+    gchar *text,
+    gdouble min,
+    gdouble max,
+    gdouble step,
+    gdouble value,
+    gint digits,
+    gdouble reset_value)
+{
+    GtkWidget *box;
+    GtkWidget *label;
+    GtkWidget *scale;
+    GtkWidget *reset;
+
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_pack_start (GTK_BOX (tab), box, TRUE, TRUE, 0);
+
+    label = gtk_label_new_with_mnemonic (text);
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_label_set_yalign (GTK_LABEL (label), 0.5);
+    gtk_widget_set_size_request (label, 120, -1);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+
+    scale = gtk_scale_new_with_range (GTK_ORIENTATION_HORIZONTAL, min, max, step);
+    gtk_scale_set_digits (GTK_SCALE (scale), digits);
+    gtk_scale_set_value_pos (GTK_SCALE (scale), GTK_POS_RIGHT);
+    gtk_range_set_value (GTK_RANGE (scale), value);
+    gtk_box_pack_start (GTK_BOX (box), scale, TRUE, TRUE, 0);
+    gtk_label_set_mnemonic_widget (GTK_LABEL (label), scale);
+
+    reset = add_reset_button (scale, reset_value);
+    gtk_box_pack_start (GTK_BOX (box), reset, FALSE, FALSE, 0);
+
+    return scale;
+}
 
 static void update_colour_setting (gchar **colour, ColourSetting *s)
 {
@@ -557,7 +700,7 @@ static ColourSetting *add_colour_setting (GtkWidget *tab, gchar *text,
 
     s = g_new (ColourSetting, 1);
 
-    s->checkbox = gtk_check_button_new_with_label (text);
+    s->checkbox = gtk_check_button_new_with_mnemonic (text);
     gtk_box_pack_start (GTK_BOX (tab), s->checkbox, TRUE, TRUE, 0);
 
     s->button = gtk_color_button_new ();
@@ -577,50 +720,99 @@ static ColourSetting *add_colour_setting (GtkWidget *tab, gchar *text,
     return s;
 }
 
-static gulong hSigScaleChanged = 0;
 
-static GtkWidget *imageScaleLabel;
-static GtkWidget *imageScale;
-
-static gint tmpImageHeight;
 static gfloat tmpImageScale;
-
-static void toggle_constant_height (GtkToggleButton *togglebutton,
-				    gpointer user_data)
-{
-    /*
-     * Apparently changing the image scale the way we do below will cause
-     * the "value_changed" signal to be emitted, which will screw things up
-     * quite badly. So we block that signal temporarily.
-     */
-    
-    g_signal_handler_block (G_OBJECT (imageScale), hSigScaleChanged);
-    
-    if (gtk_toggle_button_get_active (togglebutton))
-    {
-	gtk_label_set_text (GTK_LABEL (imageScaleLabel), "Image height:");
-	gtk_scale_set_digits (GTK_SCALE (imageScale), 0);
-	gtk_range_set_range (GTK_RANGE (imageScale), 50, 1000);
-	gtk_range_set_increments (GTK_RANGE (imageScale), 1.0, 50.0);
-	gtk_range_set_value (GTK_RANGE (imageScale), tmpImageHeight);
-    } else
-    {
-	gtk_label_set_text (GTK_LABEL (imageScaleLabel), "Scale factor:");
-	gtk_scale_set_digits (GTK_SCALE (imageScale), 2);
-	gtk_range_set_range (GTK_RANGE (imageScale), 0.1, 5.0);
-	gtk_range_set_increments (GTK_RANGE (imageScale), 0.01, 0.1);
-	gtk_range_set_value (GTK_RANGE (imageScale), tmpImageScale);
-    }
-
-    g_signal_handler_unblock (G_OBJECT (imageScale), hSigScaleChanged);
-}
+static GtkWidget *imageScale;
 
 static void change_image_scale (GtkRange *range, gpointer user_data)
 {
-    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (user_data)))
-	tmpImageHeight = (gint) gtk_range_get_value (range);
+    (void) user_data;
+    tmpImageScale = gtk_range_get_value (range);
+    Config.image_scale = tmpImageScale;
+    if (!Config.fit_to_window)
+	graphics_refresh ();
+}
+
+static void on_scale_combo_changed (GtkComboBox *combo, gpointer user_data)
+{
+    GtkWidget *scale_box = GTK_WIDGET (user_data);
+    int active = gtk_combo_box_get_active (combo);
+    Config.fit_to_window = (active == 0);
+    
+    if (scale_box)
+	gtk_widget_set_sensitive (scale_box, !Config.fit_to_window);
+    if (imageScale)
+	gtk_widget_set_sensitive (GTK_WIDGET (imageScale), !Config.fit_to_window);
+    
+    graphics_refresh ();
+}
+
+static void text_font_changed (GtkFontButton *button, gpointer user_data)
+{
+    const gchar *new_font =
+	gtk_font_chooser_get_font (GTK_FONT_CHOOSER (button));
+    if (new_font && g_utf8_validate (new_font, -1, NULL)) {
+	gchar *temp = g_strdup (new_font);
+	if (Config.text_font)
+	    g_free (Config.text_font);
+	Config.text_font = temp;
+	text_refresh ();
+    }
+}
+
+static void status_font_changed (GtkFontButton *button, gpointer user_data)
+{
+    const gchar *new_font =
+	gtk_font_chooser_get_font (GTK_FONT_CHOOSER (button));
+    if (new_font && g_utf8_validate (new_font, -1, NULL)) {
+	gchar *temp = g_strdup (new_font);
+	if (Config.status_font)
+	    g_free (Config.status_font);
+	Config.status_font = temp;
+	text_refresh ();
+    }
+}
+
+static void color_changed (GtkColorButton *button, gpointer user_data)
+{
+    gchar **target = (gchar **) user_data;
+    GdkRGBA rgba;
+    gtk_color_chooser_get_rgba (GTK_COLOR_CHOOSER (button), &rgba);
+    if (*target)
+	g_free (*target);
+    *target = g_strdup_printf ("#%02X%02X%02X",
+			    (int) (rgba.red * 255),
+			    (int) (rgba.green * 255),
+			    (int) (rgba.blue * 255));
+    if (target == &Config.graphics_bg)
+	graphics_refresh ();
     else
-	tmpImageScale = gtk_range_get_value (range);
+	text_refresh ();
+}
+
+static void on_font_reset_clicked (GtkWidget *btn, gpointer user_data)
+{
+    const gchar *name = (const gchar *) g_object_get_data (G_OBJECT (btn), "reset-font-name");
+    GtkWidget *w = GTK_WIDGET (g_object_get_data (G_OBJECT (btn), "reset-font-widget"));
+    if (w && name) {
+	gtk_font_chooser_set_font (GTK_FONT_CHOOSER (w), name);
+	g_signal_emit_by_name (w, "font-set");
+    }
+}
+
+static void color_checkbox_changed (
+    GtkToggleButton *toggle_button, gpointer user_data)
+{
+    ColourSetting *s = (ColourSetting *) user_data;
+    gchar **target = (gchar **) g_object_get_data (G_OBJECT (s->checkbox), "target-color");
+    
+    if (target) {
+	update_colour_setting (target, s);
+	if (target == &Config.graphics_bg)
+	    graphics_refresh ();
+	else
+	    text_refresh ();
+    }
 }
 
 typedef struct
@@ -651,6 +843,41 @@ static int get_interp_type_index (GdkInterpType interp_type)
     return -1;
 }
 
+static void on_filter_changed (GtkComboBox *combo, gpointer user_data)
+{
+    gint active = gtk_combo_box_get_active (combo);
+    if (active >= 0 && active < (gint) G_N_ELEMENTS (imageFilters))
+    {
+	Config.image_filter = imageFilters[active].interp_type;
+	graphics_refresh ();
+    }
+}
+
+static void on_gamma_changed (GtkRange *range, gpointer user_data)
+{
+    gdouble *target = (gdouble *) user_data;
+    *target = gtk_range_get_value (range);
+    graphics_refresh ();
+}
+
+static void on_animation_delay_changed (GtkRange *range, gpointer user_data)
+{
+    (void) user_data;
+    Config.animation_delay = (gint) gtk_range_get_value (range);
+    if (Config.animate_images)
+	graphics_refresh ();
+}
+
+static void on_animate_toggled (GtkToggleButton *button, gpointer user_data)
+{
+    GtkWidget *delay_widget = GTK_WIDGET (user_data);
+    gboolean active = gtk_toggle_button_get_active (button);
+    Config.animate_images = active;
+    if (delay_widget)
+	gtk_widget_set_sensitive (delay_widget, active);
+    graphics_refresh ();
+}
+
 void do_config ()
 {
     GtkWidget *dialog;
@@ -665,8 +892,6 @@ void do_config ()
     GtkWidget *colour_tab;
     GtkWidget *text_font;
     GtkWidget *status_font;
-    GtkWidget *constant_height;
-    GtkWidget *horizontal_split;
     GtkWidget *red_gamma;
     GtkWidget *green_gamma;
     GtkWidget *blue_gamma;
@@ -693,6 +918,7 @@ void do_config ()
 	GTK_RESPONSE_REJECT,
 	NULL);
 
+    gtk_window_set_resizable (GTK_WINDOW (dialog), FALSE);
     gtk_window_set_default_size (GTK_WINDOW (dialog), 400, 400);
 
     /* Top level */
@@ -709,14 +935,19 @@ void do_config ()
 
     graphics_tab = gtk_box_new (GTK_ORIENTATION_VERTICAL, 1);
     gtk_container_set_border_width (GTK_CONTAINER (graphics_tab), 5);
+    gtk_widget_set_margin_bottom (graphics_tab, 12);
     gtk_notebook_append_page (GTK_NOTEBOOK (tabs), graphics_tab,
 			      gtk_label_new ("Graphics"));
 
     /* Text and colour settings */
 
-    text_font = add_font_button (colour_tab, "Text font:", "Select text font");
-    status_font =
-	add_font_button (colour_tab, "Status font:", "Select status font");
+    const gchar *saved_text_font = Config.text_font ? Config.text_font : NULL;
+    const gchar *saved_status_font = Config.status_font ? Config.status_font : NULL;
+
+    text_font = add_font_button_with_reset (
+	colour_tab, "_Text font:", "Select text font", saved_text_font);
+    status_font = add_font_button_with_reset (
+	colour_tab, "Status f_ont:", "Select status font", saved_status_font);
 
     if (!Config.text_font)
     {
@@ -725,7 +956,7 @@ void do_config ()
 	gtk_font_chooser_set_font (
 	    GTK_FONT_CHOOSER (text_font), font_name);
     } else {
-        gtk_font_chooser_set_font (
+	gtk_font_chooser_set_font (
 	    GTK_FONT_CHOOSER (text_font), Config.text_font);
     }
 
@@ -737,95 +968,203 @@ void do_config ()
     gtk_font_chooser_set_font (
 	    GTK_FONT_CHOOSER (status_font), Config.status_font);
     
+    g_signal_connect (text_font, "font-set",
+	G_CALLBACK (text_font_changed), NULL);
+    g_signal_connect (status_font, "font-set",
+	G_CALLBACK (status_font_changed), NULL);
+    
+    {
+	GtkWidget *dummy;
+	GtkWidget *box;
+	GtkWidget *label;
+	GtkWidget *widget;
+
+	dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+	gtk_box_pack_start (GTK_BOX (colour_tab), dummy, FALSE, FALSE, 8);
+
+	box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+	gtk_box_pack_start (GTK_BOX (colour_tab), box, FALSE, FALSE, 0);
+
+	label = gtk_label_new_with_mnemonic ("Text _margins:");
+	gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+	gtk_widget_set_size_request (label, 120, -1);
+	gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+
+	widget = gtk_spin_button_new_with_range (0, 100, 1);
+	gtk_widget_set_size_request (widget, MIN_WINDOW_HEIGHT, -1);
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (widget), Config.text_margin);
+	gtk_box_pack_start (GTK_BOX (box), widget, TRUE, TRUE, 0);
+	gtk_label_set_mnemonic_widget (GTK_LABEL (label), widget);
+	g_signal_connect (widget, "value-changed",
+	    G_CALLBACK (spin_changed_int), &Config.text_margin);
+	gtk_box_pack_start (GTK_BOX(box),
+	    add_reset_button (widget, 20.0), FALSE, FALSE, 0);
+
+	box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+	gtk_box_pack_start (GTK_BOX (colour_tab), box, FALSE, FALSE, 0);
+
+	label = gtk_label_new_with_mnemonic ("Line _spacing:");
+	gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+	gtk_widget_set_size_request (label, 120, -1);
+	gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+
+	widget = gtk_spin_button_new_with_range (0.0, 5.0, 0.5);
+	gtk_widget_set_size_request (widget, MIN_WINDOW_HEIGHT, -1);
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (widget), Config.text_leading);
+	gtk_box_pack_start (GTK_BOX (box), widget, TRUE, TRUE, 0);
+	gtk_label_set_mnemonic_widget (GTK_LABEL (label), widget);
+	g_signal_connect (widget, "value-changed",
+	    G_CALLBACK (spin_changed_float), &Config.text_leading);
+	gtk_box_pack_start (GTK_BOX(box),
+	    add_reset_button (widget, 1.0), FALSE, FALSE, 0);
+
+	dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+	gtk_box_pack_start (GTK_BOX (colour_tab), dummy, FALSE, FALSE, 8);
+    }
+
     text_fg = add_colour_setting (
-	colour_tab, "Override text foreground colour",
+	colour_tab, "Override text _foreground colour",
 	"Select text foreground colour", Config.text_fg);
+    g_object_set_data (G_OBJECT (text_fg->checkbox), "target-color", &Config.text_fg);
+    g_signal_connect (text_fg->button, "color-set",
+	G_CALLBACK (color_changed), &Config.text_fg);
+    g_signal_connect (text_fg->checkbox, "toggled",
+	G_CALLBACK (color_checkbox_changed), text_fg);
+    
     text_bg = add_colour_setting (
-	colour_tab, "Override text background colour",
+	colour_tab, "Override text _background colour",
 	"Select text background colour", Config.text_bg);
+    g_object_set_data (G_OBJECT (text_bg->checkbox), "target-color", &Config.text_bg);
+    g_signal_connect (text_bg->button, "color-set",
+	G_CALLBACK (color_changed), &Config.text_bg);
+    g_signal_connect (text_bg->checkbox, "toggled",
+	G_CALLBACK (color_checkbox_changed), text_bg);
+    
     status_fg = add_colour_setting (
-	colour_tab, "Override statusline foreground colour",
+	colour_tab, "Override stat_usline foreground colour",
 	"Select statusline foreground colour", Config.status_fg);
+    g_object_set_data (G_OBJECT (status_fg->checkbox), "target-color", &Config.status_fg);
+    g_signal_connect (status_fg->button, "color-set",
+	G_CALLBACK (color_changed), &Config.status_fg);
+    g_signal_connect (status_fg->checkbox, "toggled",
+	G_CALLBACK (color_checkbox_changed), status_fg);
+    
     status_bg = add_colour_setting (
 	colour_tab, "Override statusline background colour",
 	"Select statusline background colour", Config.status_bg);
+    g_object_set_data (G_OBJECT (status_bg->checkbox), "target-color", &Config.status_bg);
+    g_signal_connect (status_bg->button, "color-set",
+	G_CALLBACK (color_changed), &Config.status_bg);
+    g_signal_connect (status_bg->checkbox, "toggled",
+	G_CALLBACK (color_checkbox_changed), status_bg);
+    
     graphics_bg = add_colour_setting (
-	colour_tab, "Override picture background colour",
+	colour_tab, "Override picture back_ground colour",
 	"Select picture background colour", Config.graphics_bg);
+    g_object_set_data (G_OBJECT (graphics_bg->checkbox), "target-color", &Config.graphics_bg);
+    g_signal_connect (graphics_bg->button, "color-set",
+	G_CALLBACK (color_changed), &Config.graphics_bg);
+    g_signal_connect (graphics_bg->checkbox, "toggled",
+	G_CALLBACK (color_checkbox_changed), graphics_bg);
  
     /* Picture settings */
 
-    constant_height = gtk_check_button_new_with_label (
-	"Scale image to constant height");
-    gtk_toggle_button_set_active (
-	GTK_TOGGLE_BUTTON (constant_height), Config.image_constant_height);
-    gtk_box_pack_start (
-	GTK_BOX (graphics_tab), constant_height, TRUE, TRUE, 0);
-
-    g_signal_connect (
-	G_OBJECT (constant_height), "toggled",
-	G_CALLBACK (toggle_constant_height), NULL);
-
-    imageScaleLabel = gtk_label_new (NULL);
-    gtk_label_set_xalign (GTK_LABEL (imageScaleLabel), 0.0);
-    gtk_label_set_yalign (GTK_LABEL (imageScaleLabel), 0.5);
-    gtk_box_pack_start (
-	GTK_BOX (graphics_tab), imageScaleLabel, TRUE, TRUE, 0);
-
-    imageScale = gtk_scale_new (GTK_ORIENTATION_HORIZONTAL, NULL);
-    gtk_scale_set_value_pos (GTK_SCALE (imageScale), GTK_POS_RIGHT);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), imageScale, TRUE, TRUE, 0);
-
-    hSigScaleChanged = g_signal_connect (
-	G_OBJECT (imageScale), "value-changed",
-	G_CALLBACK (change_image_scale), constant_height);
-    
-    tmpImageScale = Config.image_scale;
-    tmpImageHeight = Config.image_height;
-    
-    toggle_constant_height (GTK_TOGGLE_BUTTON (constant_height), NULL);
-
-    dummy = gtk_label_new ("Interpolation mode:");
-    gtk_label_set_xalign (GTK_LABEL (dummy), 0.0);
-    gtk_label_set_yalign (GTK_LABEL (dummy), 0.5);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, TRUE, TRUE, 0);
-
-    image_filter = gtk_combo_box_text_new ();
-    gtk_box_pack_start (GTK_BOX (graphics_tab), image_filter, TRUE, TRUE, 0);
-
-    for (i = 0; i < G_N_ELEMENTS (imageFilters); i++)
     {
-	gtk_combo_box_text_append_text(
-	    GTK_COMBO_BOX_TEXT (image_filter), imageFilters[i].description);
+	static const gchar *filter_items[] = {
+	    "Nearest neighbour",
+	    "Tiles",
+	    "Bilinear",
+	    "Hyperbolic"
+	};
+	image_filter = add_combo_box_simple (
+	    graphics_tab,
+	    "_Interpolation:",
+	    (const gchar **) filter_items,
+	    G_N_ELEMENTS (filter_items),
+	    get_interp_type_index (Config.image_filter));
+	g_signal_connect (G_OBJECT (image_filter), "changed",
+	    G_CALLBACK (on_filter_changed), NULL);
     }
 
-    gtk_combo_box_set_active (
-	GTK_COMBO_BOX (image_filter),
-	get_interp_type_index (Config.image_filter));
+    {
+	GtkWidget *position_combo;
+	static const gchar *position_items[] = {
+	    "Top",
+	    "Bottom",
+	    "Left",
+	    "Right",
+	    "Hidden"
+	};
+	position_combo = add_combo_box_simple (
+	    graphics_tab, "Graphics _position:",
+	    (const gchar **) position_items, G_N_ELEMENTS (position_items),
+	    Config.graphics_position);
+	g_signal_connect (G_OBJECT (position_combo), "changed",
+	G_CALLBACK (on_position_changed), NULL);
+    }
+
+    {
+	GtkWidget *scale_combo;
+	GtkWidget *scale_box;
+	static const gchar *scale_items[] = {
+	    "Fit to window",
+	    "Custom scale"
+	};
+    	scale_combo = add_combo_box_simple (
+    	    graphics_tab, "_Scaling mode:",
+    	    (const gchar **) scale_items, G_N_ELEMENTS (scale_items),
+    	    Config.fit_to_window ? 0 : 1);
+	gtk_combo_box_set_active (
+	    GTK_COMBO_BOX (scale_combo), Config.fit_to_window ? 0 : 1);
+
+	scale_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 3);
+	gtk_box_pack_start (GTK_BOX (graphics_tab), scale_box, TRUE, TRUE, 0);
+
+	imageScale = add_scale_with_reset (
+	    scale_box, "Scale _factor:", 0.1, 5.0, 0.1, Config.image_scale, 2, 1.0);
+	g_signal_connect (imageScale, "value-changed",
+	    G_CALLBACK (change_image_scale), NULL);
+
+	tmpImageScale = Config.image_scale;
+
+	gtk_widget_set_sensitive (scale_box, !Config.fit_to_window);
+
+	g_signal_connect (G_OBJECT (scale_combo), "changed",
+	    G_CALLBACK (on_scale_combo_changed), scale_box);
+    }
 
     dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, TRUE, TRUE, 8);
+    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, FALSE, FALSE, 8);
 
-    red_gamma = add_scale (
-	graphics_tab, "Red gamma:", 0.1, 5.0, 0.1, Config.red_gamma);
-    green_gamma = add_scale (
-	graphics_tab, "Green gamma:", 0.1, 5.0, 0.1, Config.green_gamma);
-    blue_gamma = add_scale (
-	graphics_tab, "Blue gamma:", 0.1, 5.0, 0.1, Config.blue_gamma);
+    red_gamma = add_scale_with_reset (
+	graphics_tab, "_Red gamma:", 0.1, 5.0, 0.1, Config.red_gamma, 2, 1.0);
+    g_signal_connect (red_gamma, "value-changed",
+	G_CALLBACK (on_gamma_changed), &Config.red_gamma);
+    green_gamma = add_scale_with_reset (
+	graphics_tab, "_Green gamma:", 0.1, 5.0, 0.1, Config.green_gamma, 2, 1.0);
+    g_signal_connect (green_gamma, "value-changed",
+	G_CALLBACK (on_gamma_changed), &Config.green_gamma);
+    blue_gamma = add_scale_with_reset (
+	graphics_tab, "_Blue gamma:", 0.1, 5.0, 0.1, Config.blue_gamma, 2, 1.0);
+    g_signal_connect (blue_gamma, "value-changed",
+	G_CALLBACK (on_gamma_changed), &Config.blue_gamma);
 
     dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, TRUE, TRUE, 8);
+    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, FALSE, FALSE, 8);
 
-    animate_images = gtk_check_button_new_with_label ("Animate images");
-    gtk_box_pack_start (GTK_BOX (graphics_tab), animate_images, TRUE, TRUE, 0);
-
-    animation_delay = add_scale (
-	graphics_tab, "Animation delay (ms):", 50.0, 500.0, 10.0,
-	Config.animation_delay);
-    gtk_scale_set_digits (GTK_SCALE (animation_delay), 0);
-    
+    animate_images = gtk_check_button_new_with_mnemonic ("_Animate images");
     gtk_toggle_button_set_active (
 	GTK_TOGGLE_BUTTON (animate_images), Config.animate_images);
+    gtk_box_pack_start (GTK_BOX (graphics_tab), animate_images, TRUE, TRUE, 0);
+
+    animation_delay = add_scale_with_reset (
+	graphics_tab, "Animation _delay (ms):", 50.0, 500.0, 10.0,
+	Config.animation_delay, 0, 100.0);
+    g_signal_connect (animation_delay, "value-changed",
+	G_CALLBACK (on_animation_delay_changed), NULL);
+    
+    g_signal_connect (animate_images, "toggled",
+	G_CALLBACK (on_animate_toggled), animation_delay);
     gtk_widget_set_sensitive (
 	GTK_WIDGET (animation_delay), Config.animate_images);
 
@@ -833,15 +1172,19 @@ void do_config ()
 	G_OBJECT (animate_images), "toggled", G_CALLBACK (toggle_sensitivity),
 	animation_delay);
 
-    /* Run the dialog */
-
     dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, TRUE, TRUE, 8);
+    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, FALSE, FALSE, 8);
 
-    horizontal_split = gtk_check_button_new_with_mnemonic ("_Horizontal split");
+    GtkWidget *auto_graphics_magwin;
+    auto_graphics_magwin = gtk_check_button_new_with_mnemonic (
+	"Auto-enable graphics for Magneti_c Windows games");
     gtk_toggle_button_set_active (
-        GTK_TOGGLE_BUTTON (horizontal_split), Config.horizontal_split);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), horizontal_split, TRUE, TRUE, 0);
+	GTK_TOGGLE_BUTTON (auto_graphics_magwin),
+	Config.auto_graphics_magwin);
+    gtk_box_pack_start (GTK_BOX (graphics_tab), auto_graphics_magwin,
+			TRUE, TRUE, 0);
+
+    /* Run the dialog */
 
     gtk_widget_show_all (gtk_dialog_get_content_area (GTK_DIALOG (dialog)));
     if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
@@ -860,10 +1203,6 @@ void do_config ()
 	update_colour_setting (&(Config.status_bg), status_bg);
 	update_colour_setting (&(Config.graphics_bg), graphics_bg);
 
-	Config.image_constant_height =
-	    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (constant_height));
-	Config.image_scale = tmpImageScale;
-	Config.image_height = tmpImageHeight;
 	Config.red_gamma = gtk_range_get_value (GTK_RANGE (red_gamma));
 	Config.green_gamma = gtk_range_get_value (GTK_RANGE (green_gamma));
 	Config.blue_gamma = gtk_range_get_value (GTK_RANGE (blue_gamma));
@@ -872,6 +1211,9 @@ void do_config ()
 	    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (animate_images));
 	Config.animation_delay =
 	    (gint) gtk_range_get_value (GTK_RANGE (animation_delay));
+	Config.auto_graphics_magwin =
+	    gtk_toggle_button_get_active (
+		GTK_TOGGLE_BUTTON (auto_graphics_magwin));
 
  	filter_idx = gtk_combo_box_get_active (GTK_COMBO_BOX (image_filter));
 	if (filter_idx != -1)
@@ -879,8 +1221,6 @@ void do_config ()
 	else
 	    Config.image_filter = GDK_INTERP_BILINEAR;
 	
-	Config.horizontal_split =
-	    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (horizontal_split));
 	write_config_file ();
 
 	/* Apply settings */

--- a/Gtk/config.h
+++ b/Gtk/config.h
@@ -52,6 +52,8 @@ typedef struct
     gint hints_height;
     
     gchar *text_font;
+    gint text_margin;
+    gdouble text_leading;
     gchar *text_fg;
     gchar *text_bg;
     gchar *status_font;
@@ -59,6 +61,7 @@ typedef struct
     gchar *status_bg;
     
     gboolean image_constant_height;
+    gboolean fit_to_window;
     gdouble image_scale;
     gint image_height;
     gint image_filter;     /* Should really be GdkInterpType, not gint */
@@ -68,7 +71,8 @@ typedef struct
     gchar *graphics_bg;
     gboolean animate_images;
     gint animation_delay;
-    gboolean horizontal_split;
+    gint graphics_position;
+    gboolean auto_graphics_magwin;
 } Configuration;
 
 extern Configuration Config;

--- a/Gtk/main.c
+++ b/Gtk/main.c
@@ -100,6 +100,7 @@ static gboolean main_loop (gpointer data)
 	    ms_stop ();
 	    ms_freemem ();
 
+	    text_block_input ();
 	    gtk_text_view_scroll_mark_onscreen (
 		GTK_TEXT_VIEW (Gui.text_view),
 		gtk_text_buffer_get_insert (Gui.text_buffer));
@@ -209,7 +210,7 @@ void do_about ()
 	"Copyright (C) 1997-2023 Niclas Karlsson",
 
 	"comments",
-	"GTK 3.24 interface v2.0 by thr <r@sledinmay.com> ported from\n"
+	"GTK 3.24 interface v2.1 by thr <r@sledinmay.com> ported from\n"
 	"GTK+ 2.6 interface v1.6 by Torbj\303\266rn Andersson <d91tan@Update.UU.SE>",
 
 	"authors",
@@ -229,7 +230,6 @@ void do_about ()
 	"You should have received a copy of the GNU General Public License\n"
 	"along with this program; if not, write to the Free Software\n"
 	"Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111, USA.\n",
-
 	NULL);
 
     gtk_widget_destroy (about);
@@ -328,8 +328,15 @@ gboolean start_new_game (gchar *game_filename, gchar *graphics_filename,
 	g_free (basename);
 	gtk_widget_destroy (error);
     } else
+    {
+	if (ms_is_magwin () && Config.auto_graphics_magwin)
+	{
+	    text_set_magwin_graphics ();
+	}
+
 	start_main_loop ();
-    
+    }
+
     g_free (game_filename);
     g_free (graphics_filename);
     g_free (splash_filename);

--- a/Gtk/text.h
+++ b/Gtk/text.h
@@ -29,7 +29,10 @@ void stop_replaying (gboolean silent);
 
 void text_init (void);
 void text_clear (void);
+void text_block_input (void);
 void text_refresh (void);
 void text_insert (gchar *fmt, ...) G_GNUC_PRINTF (1, 2);
+void text_send_command (const gchar *cmd);
+void text_set_magwin_graphics (void);
 
 #endif


### PR DESCRIPTION
Finally got around to porting the QoL stuff from Level 9: readability fixes, graphics scale-to-fit and enhanced positioning, modernised settings, and quit confirmation dialog. Fixed a couple ancient bugs while I was at it.

The one thing bugging me was how magwin versions would start with pictures turned off by default, which requires the player to type "graphics on" the first thing when running a game. So there's now an option to turn them on automatically at the start. This only works for games that need it, so it's safe to leave this option turned on even for games that show graphics by default.

See NEWS for a detailed changelog.

<img width="1226" height="888" alt="corr" src="https://github.com/user-attachments/assets/a693522e-57f9-4e2e-a293-be621d308aee" />
