### PR TITLE
Auto-graphics, sound and stability fixes

### DIFF
--- a/Gtk/NEWS
+++ b/Gtk/NEWS
@@ -12,6 +12,8 @@ Bugfixes
   divider and the window edge to prevent accidentally collapsing either
   pane to zero width or height during window resizing.
 
+- MIDI music from Wonderland will no longer play between games.
+
 Other changes
 
 - Improved font rendering quality with antialiasing, light hinting

--- a/Gtk/config.c
+++ b/Gtk/config.c
@@ -906,7 +906,6 @@ void do_config ()
     GtkWidget *animation_delay;
     GtkWidget *image_filter;
     gint filter_idx = 0;
-    gint i;
 
     /*
      * Some settings, such as the partition, may have changed since they were

--- a/Gtk/graphics.h
+++ b/Gtk/graphics.h
@@ -20,7 +20,7 @@
 #ifndef _GRAPHICS_H
 #define _GRAPHICS_H
 
-void display_splash_screen (gchar *splash_filenam, gchar *music_filename);
+void display_splash_screen (gchar *splash_filename, gchar *music_filename);
 void graphics_init (void);
 void graphics_clear (void);
 void graphics_refresh (void);

--- a/Gtk/main.c
+++ b/Gtk/main.c
@@ -95,15 +95,19 @@ static gboolean main_loop (gpointer data)
 	if (!result)
 	{
 	    text_insert ("\n[End of session]\n");
-	    mainIdleHandler = 0;
+	    stop_main_loop ();
 	    ms_flush ();
 	    ms_stop ();
 	    ms_freemem ();
 
-	    text_block_input ();
-	    gtk_text_view_scroll_mark_onscreen (
-		GTK_TEXT_VIEW (Gui.text_view),
-		gtk_text_buffer_get_insert (Gui.text_buffer));
+	    if (Gui.text_view && GTK_IS_TEXT_VIEW (Gui.text_view) &&
+		Gui.text_buffer && GTK_IS_TEXT_BUFFER (Gui.text_buffer))
+	    {
+		text_block_input ();
+		gtk_text_view_scroll_mark_onscreen (
+		    GTK_TEXT_VIEW (Gui.text_view),
+		    gtk_text_buffer_get_insert (Gui.text_buffer));
+	    }
 	    break;
 	}
     }
@@ -306,6 +310,7 @@ gboolean start_new_game (gchar *game_filename, gchar *graphics_filename,
     text_clear ();
     graphics_clear ();
     hints_clear ();
+    sound_stop_music ();
 
     if (applicationExiting)
 	return FALSE;
@@ -329,11 +334,6 @@ gboolean start_new_game (gchar *game_filename, gchar *graphics_filename,
 	gtk_widget_destroy (error);
     } else
     {
-	if (ms_is_magwin () && Config.auto_graphics_magwin)
-	{
-	    text_set_magwin_graphics ();
-	}
-
 	start_main_loop ();
     }
 

--- a/Gtk/text.h
+++ b/Gtk/text.h
@@ -32,7 +32,7 @@ void text_clear (void);
 void text_block_input (void);
 void text_refresh (void);
 void text_insert (gchar *fmt, ...) G_GNUC_PRINTF (1, 2);
-void text_send_command (const gchar *cmd);
-void text_set_magwin_graphics (void);
+gboolean text_has_active_input (void);
+void text_set_magwin_graphics (gboolean allow);
 
 #endif

--- a/Win/MagneticView.h
+++ b/Win/MagneticView.h
@@ -104,7 +104,8 @@ public:
   static BOOL OpenGame(LPCTSTR lpszPathName);
   static char GetInput(bool& done, bool trans);
   static char GetPlaybackChar(FILE* file);
-  void ResetGfxOnSent(void) { m_bGfxOnSent = false; }
+  bool IsInputActive(void) const { return m_bInputActive; }
+  bool m_bAllowAutoGfx;
 
 protected:
   void SolidRect(CDC* pDC, LPCRECT lpRect, COLORREF Colour);
@@ -153,7 +154,6 @@ protected:
   bool m_bMorePrompt;
   bool m_bCaret;
   bool m_bInputActive;
-  bool m_bGfxOnSent;
 
   CString m_strOutput;
   CArray<int,int> m_Input;


### PR DESCRIPTION
A handful of usability and bug fixes.

GTK & Windows:
MagWin auto-graphics will activate only when starting or restarting the game, and not during gameplay. Previously, disabling the graphics with the "graphics" toggle command would quite impolitely turn them back on.

GTK:
Auto-graphics now works when "restart"-ing the game (or using "quit" to that effect), as mentioned in #9.

Wonderland MIDI music now stops playing when loading a new game file, as it had been persisting even between different games.

Added null checks for text view and buffer, and fixed idle handler cleanup to improve stability and responsiveness.